### PR TITLE
Route Filters

### DIFF
--- a/app/Routing/Filter/After/ResourceHttpCacheFilter.php
+++ b/app/Routing/Filter/After/ResourceHttpCacheFilter.php
@@ -7,7 +7,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Route;
 
-class PostCacheFilter
+class ResourceHttpCacheFilter
 {
     const ONE_DAY = 86400;
 

--- a/app/Routing/Filter/Before/ResourceHttpCacheFilter.php
+++ b/app/Routing/Filter/Before/ResourceHttpCacheFilter.php
@@ -8,7 +8,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Route;
 
-class PostCacheFilter
+class ResourceHttpCacheFilter
 {
     /** @var Site */
     protected $site;
@@ -28,8 +28,8 @@ class PostCacheFilter
             return;
         }
 
-        /** @var \Baileylo\Blog\Post\Post $post */
-        $post = $route->getParameter('postSlug');
+        /** @var \Baileylo\Blog\Post\Post|\Baileylo\Blog\Page\Page $post */
+        $post = $route->getParameter('slug');
 
         $response = new Response();
         $response->setLastModified($post->getUpdatedAt());

--- a/app/Routing/Filter/Before/UnpublishedResourceAccessFilter.php
+++ b/app/Routing/Filter/Before/UnpublishedResourceAccessFilter.php
@@ -3,16 +3,20 @@
 namespace Baileylo\BlogApp\Routing\Filter\Before;
 
 use Baileylo\Blog\Page\Page;
+use Baileylo\Blog\Post\Post;
 use Illuminate\Auth\AuthManager;
-use Illuminate\Http\Request;
 use Illuminate\Routing\Redirector;
 use Illuminate\Routing\Route;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
-class PageFilter
+/**
+ * Prevents access to unpublished resources.
+ */
+class UnpublishedResourceAccessFilter
 {
     /** @var AuthManager */
     private $manager;
+
     /** @var Redirector */
     private $redirector;
 
@@ -22,20 +26,10 @@ class PageFilter
         $this->redirector = $redirector;
     }
 
-    public function unpublished(Route $route)
-    {
-        /** @var Page $page */
-        $page = $route->getParameter('pageSlug');
-        if ($page->isPublished()) {
-            return $this->redirector->route('page', [$page->getSlug()]);
-        }
-    }
-
-    public function published(Route $route)
+    public function filter(Route $route)
     {
         /** @var Page|Post $page */
         $page = $route->getParameter('slug');
-
         if ($this->manager->guest() && !$page->isPublished()) {
             throw new NotFoundHttpException;
         }

--- a/app/Routing/Filter/RoutingFilterServiceProvider.php
+++ b/app/Routing/Filter/RoutingFilterServiceProvider.php
@@ -15,10 +15,12 @@ class RoutingFilterServiceProvider extends ServiceProvider
         /** @var \Illuminate\Routing\Router $router */
         $router = $this->app['router'];
         $router->filter('beforeAtomCache', Before\AtomCacheFilter::class);
-        $router->filter('beforePostCache', Before\PostCacheFilter::class);
+        $router->filter('beforeResourceCache', Before\ResourceHttpCacheFilter::class);
         $router->filter('afterAtomCache', After\AtomCacheFilter::class);
-        $router->filter('afterPostCache', After\PostCacheFilter::class);
+        $router->filter('afterResourceCache', After\ResourceHttpCacheFilter::class);
         $router->filter('postUrlRedirect', Before\PostUrlRedirect::class);
+
+        $router->filter('unpublishedResource', Before\UnpublishedResourceAccessFilter::class);
 
         $router->before(Before\LowerCaseUrlsFilter::class);
     }

--- a/app/routes.php
+++ b/app/routes.php
@@ -77,8 +77,7 @@ Route::group(['before' => 'auth'], function () {
 Route::get('{date}/{slug}', ['before' => 'postUrlRedirect']);
 
 // View
-Route::get('{slug}', ['uses' => Controllers\Resource\View::class . '@view', 'as' => 'page.permalink']);
-Route::get('{slug}', ['uses' => Controllers\Resource\View::class . '@view', 'as' => 'post.permalink']);
-
+Route::get('{slug}', ['uses' => Controllers\Resource\View::class . '@view', 'as' => 'page.permalink', 'before' => 'unpublishedResource|beforeResourceCache', 'after' => 'afterResourceCache']);
+Route::get('{slug}', ['uses' => Controllers\Resource\View::class . '@view', 'as' => 'post.permalink', 'before' => 'unpublishedResource|beforeResourceCache', 'after' => 'afterResourceCache']);
 
 

--- a/app/routes.php
+++ b/app/routes.php
@@ -48,6 +48,10 @@ Route::group(['before' => 'auth'], function () {
     Route::get('/write', ['uses' => Controllers\Post\Create\View::class . '@view', 'as' => 'admin.post.create']);
     Route::get('/write/page', ['uses' => Controllers\Page\Create\View::class . '@view', 'as' => 'admin.page.create']);
 
+    // Edit
+    Route::get('{slug}/edit', ['uses' => Controllers\Resource\Edit::class . '@view', 'as' => 'page.edit']);
+    Route::get('{slug}/edit', ['uses' => Controllers\Resource\Edit::class . '@view', 'as' => 'post.edit']);
+
     Route::group(['before' => 'csrf'], function () {
         // Delete Page Or Post
         Route::delete('{slug}', ['uses' => Controllers\Resource\Delete::class . '@delete', 'as' => 'page.delete']);
@@ -76,8 +80,5 @@ Route::get('{date}/{slug}', ['before' => 'postUrlRedirect']);
 Route::get('{slug}', ['uses' => Controllers\Resource\View::class . '@view', 'as' => 'page.permalink']);
 Route::get('{slug}', ['uses' => Controllers\Resource\View::class . '@view', 'as' => 'post.permalink']);
 
-// Edit
-Route::get('{slug}/edit', ['uses' => Controllers\Resource\Edit::class . '@view', 'as' => 'page.edit']);
-Route::get('{slug}/edit', ['uses' => Controllers\Resource\Edit::class . '@view', 'as' => 'post.edit']);
 
 


### PR DESCRIPTION
`Routing\Filter\Before\PostCacheFilter` and `Routing\Filter\After\PostCacheFilter` should be renamed to `ResourceCacheFilter` since they're applied to both Pages and Posts.

We should add a ACL filter, currently this only needs to be for viewing unpublished Pages and Posts, I don't think there is a need to bring in a full ACL.
