### PR TITLE
Redirect Fails on Post Errors

### DIFF
--- a/app/Controller/Post/Create/CreatePostHandler.php
+++ b/app/Controller/Post/Create/CreatePostHandler.php
@@ -35,11 +35,9 @@ class CreatePostHandler extends Controller
         $response = $this->creationService->handle($post, $data);
 
         if ($response->hasErrors()) {
-            $this->redirector->back()->withInput()->withErrors($response->getErrors());
+            return $this->redirector->back()->withInput()->withErrors($response->getErrors());
         }
 
-        $post = $response->getPost();
-
-        return $this->redirector->route('post.permalink', [$post->getSlug()]);
+        return $this->redirector->route('post.permalink', [$response->getPost()->getSlug()]);
     }
 }


### PR DESCRIPTION
When creating a new post, if there are any validation errors the correct redirection fails.
