### PR TITLE
Log Exceptions to Laravel.log

### DIFF
--- a/app/start/global.php
+++ b/app/start/global.php
@@ -54,9 +54,11 @@ App::error(function ($exception, $code) {
             return Response::view('errors.404', array(), 404);
 
         case 500:
+            Log::error($exception);
             return Response::view('errors.500', array(), 500);
 
         default:
+            Log::error($exception);
             return Response::view('errors.default', array(), $code);
     }
 });


### PR DESCRIPTION
We should log all 500 or default exceptions to the laravel log.
