### PR TITLE
Mongo Config Updates

### DIFF
--- a/Core/Mongo/MongoODMServiceProvider.php
+++ b/Core/Mongo/MongoODMServiceProvider.php
@@ -37,14 +37,15 @@ class MongoODMServiceProvider extends ServiceProvider
 
         $this->app->singleton('mongodb.connection', function ($app) {
             $config = $app['config']['database.mongodb'];
+            $options = array_filter($config['options']);
 
-            $server = "mongodb://{$config['host']}/{$config['collection']}";
+            $server = rtrim("{$config['host']}/{$config['collection']}", '/');
 
-            return new \MongoClient($server, $config['options']);
+            return new \MongoClient($server, $options);
         });
 
         $this->app->singleton('mongodb.database', function ($app) {
-            return $app['mongodb.connection'];
+            return $app['mongodb.connection']->{$app['config']['database.mongodb.blog']};
         });
 
         $this->app->singleton(DocumentManager::class, function ($app) {

--- a/app/config/database.php
+++ b/app/config/database.php
@@ -116,8 +116,8 @@ return array(
         'host' => 'mongodb://localhost:27017',
         'collection' => 'blog',
         'options' => [
-            'password' => $_ENV['MONGO_USER'],
-            'username' => $_ENV['MONGO_PASSWORD']
+            'password' => isset($_ENV['MONGO_PASSWORD']) ? $_ENV['MONGO_PASSWORD'] : '',
+            'username' => isset($_ENV['MONGO_USER']) ? $_ENV['MONGO_USER'] : ''
         ]
     ]
 


### PR DESCRIPTION
This fixes a lot of issues introduced by #33 
1. Fixes double mongodb protocol, protocol is now expected in the config not in the service provider.
2. Fixes undefined environment variable. `isset` is added when the config is built.
3. Removes unspecified mongodb options.
